### PR TITLE
Fix access to `extra` config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ By default, images embedded with the `img` shortcode will be inserted as a `figu
 
 ![Default sized image](pics/img_default.png)
 
-With the `extended_width_pct` argument, we can specify a percentage of how much the image should expand outside its default figure width, up to your maximum configured image width (`config.extras.images.max_width`, 2500px default).
+With the `extended_width_pct` argument, we can specify a percentage of how much the image should expand outside its default figure width, up to your maximum configured image width (`config.extra.images.max_width`, 2500px default).
 
 Here's an example with `extended_width_pct=0.1`:
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,8 +4,8 @@
 {% block title %}{{ page.title }} - {{ config.title }}{% endblock %}
 
 {% block ogp_head %}
-    {% if config.extras.ogp.locale %}
-    <meta property="og:locale" content="{{ config.extras.ogp.locale }}">
+    {% if config.extra.ogp.locale %}
+    <meta property="og:locale" content="{{ config.extra.ogp.locale }}">
     {% endif %}
     <meta property="og:title" content="{{ page.title }}">
     {% if page.components is containing("projects") or page.components is containing("blog") %}


### PR DESCRIPTION
Hey Justin,

just came across your theme to dig into `extra` usage in Zola.

I noticed a few instances of `extras` and I think those are typos. Those in the template might not be caught due to the way `{{ if … }}` works.

I haven't actually tested it out but decided to give you a hint anyway in case this is an oversight.

Cheers!