### PR TITLE
Make code/docs consistent for `papaya_menu_links`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ env = "ZOLA_ENV"
 papaya_date_format="%B %e, %Y"
 
 # Top navigation menu links
-menu_links = [
+papaya_menu_links = [
     { url = "$BASE_URL/projects/", name = "Projects" },
     { url = "$BASE_URL/blog/", name = "Blog" },
     { url = "$BASE_URL/about/", name = "About" }

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
         <nav>
             <ul>
             {% block nav_bar %}
-            {% for menu_link in config.extra.menu_links %}
+            {% for menu_link in config.extra.papaya_menu_links %}
             {% set link_url = menu_link.url | replace(from="$BASE_URL", to=config.base_url) %}
             <li><a {% if current_url and current_url == link_url %}class="active"{% endif %} href="{{ link_url }}">{{menu_link.name}}</a></li>
             {% endfor %}

--- a/theme.toml
+++ b/theme.toml
@@ -14,7 +14,7 @@ demo = "https://justintennant.me/papaya"
 [extra]
 env = "$ZOLA_ENV"
 papaya_date_format = "%e %B %Y"
-menu_links = []
+papaya_menu_links = []
 
 [extra.images]
 


### PR DESCRIPTION
README.md used `papaya_menu_links` name but the code used `menu_links`.
The prefixed version is preferred to avoid conflicts with other themes
(since a site could use multiple themes).