### PR TITLE
Add svg support to img shortcode

### DIFF
--- a/templates/shortcodes/img.html
+++ b/templates/shortcodes/img.html
@@ -14,26 +14,29 @@
     {% set img_path = path %}
 {% endif %}
 
-{% set image_quality = 90 %}
-{% if quality %}
-    {% set image_quality = quality %}
-{% endif %}
+{% if path is not ending_with(".svg") %}
+    {% set resize = true %}
+    {% set image_quality = 90 %}
+    {% if quality %}
+        {% set image_quality = quality %}
+    {% endif %}
 
-{% if extended_width_pct %}
-    {% if extended_width_pct == -1 %}
-        {# adjust extended width to container width #}
-        {% set extended_width_pct = 0.042 %}
+    {% if extended_width_pct %}
+        {% if extended_width_pct == -1 %}
+            {# adjust extended width to container width #}
+            {% set extended_width_pct = 0.042 %}
+        {% endif %}
+        {% set _width = config.extra.images.max_width - figure_width %}
+        {% set extended_width = (extended_width_pct * _width + figure_width) | round | int %}
+        {% if extended_width > config.extra.images.max_width %}
+            {% set extended_width = config.extra.images.max_width %}
+        {% endif %}
+        {% set resized_image = resize_image(path=img_path, width=extended_width, op="fit_width", quality=image_quality) %}
+    {% else %}
+        {% set resized_image = resize_image(path=img_path, width=figure_width, op="fit_width", quality=image_quality) %}
     {% endif %}
-    {% set _width = config.extra.images.max_width - figure_width %}
-    {% set extended_width = (extended_width_pct * _width + figure_width) | round | int %}
-    {% if extended_width > config.extra.images.max_width %}
-        {% set extended_width = config.extra.images.max_width %}
-    {% endif %}
-    {% set resized_image = resize_image(path=img_path, width=extended_width, op="fit_width", quality=image_quality) %}
-{% else %}
-    {% set resized_image = resize_image(path=img_path, width=figure_width, op="fit_width", quality=image_quality) %}
 {% endif %}
 <figure {% if extended_width_pct %}class="extended-figure"{% endif %}>
-    <img src="{{ resized_image.url }}" class="{% if class %}{{class}}{% endif %}" {% if alt %}alt="{{alt}}"{% endif %}/>
+    <img src="{% if resize %}{{ resized_image.url }}{% else %}{{ path }}{% endif %}" class="{% if class %}{{class}}{% endif %}" {% if alt %}alt="{{alt}}"{% endif %}/>
     {% if caption %}<figcaption>{{ caption | safe }}</figcaption>{% endif %}
 </figure>


### PR DESCRIPTION
Hi there,

I tried to use an `.svg` with the `img` shortcode and it broke. 

```
Failed to build the site
Reason: Failed to render img shortcode
Reason: Failed to render 'shortcodes/img.html'
Reason: Variable `resized_image.url` not found in context while rendering 'shortcodes/img.html'
```

I made a small update to the shortcode to fix it.