### PR TITLE
Don't add an empty class tag if there's no class specified on the image

### DIFF
--- a/templates/shortcodes/img.html
+++ b/templates/shortcodes/img.html
@@ -37,6 +37,6 @@
     {% endif %}
 {% endif %}
 <figure {% if extended_width_pct %}class="extended-figure"{% endif %}>
-    <img src="{% if resize %}{{ resized_image.url }}{% else %}{{ path }}{% endif %}" class="{% if class %}{{class}}{% endif %}" {% if alt %}alt="{{alt}}"{% endif %}/>
+    <img src="{% if resize %}{{ resized_image.url }}{% else %}{{ path }}{% endif %}" {% if class %}class="{{class}}"{% endif %} {% if alt %}alt="{{alt}}"{% endif %}/>
     {% if caption %}<figcaption>{{ caption | safe }}</figcaption>{% endif %}
 </figure>


### PR DESCRIPTION
I noticed that if `class` is not specified in the image when generating a page using `img()`, HTML code gets generated like so with an empty `class` tag, which seems unnecessary:
```
<img src="http://path/to/image.jpg" class>
```

With this change it will instead generate:
```
<img src="http://path/to/image.jpg">
```