### PR TITLE
Added shortcode for embedding YouTube videos at 16:9

### DIFF
--- a/sass/base.scss
+++ b/sass/base.scss
@@ -459,6 +459,20 @@ figcaption {
     }
 }
 
+/* 16:9 Video */
+div.video {
+    position: relative;
+    padding-top: 56.25%;
+}
+
+div.video iframe {
+    position: absolute;
+    top:0;
+    left:0;
+    width:100%;
+    height:100%;
+}
+
 /* Other pages */
 .terms {
     list-style-type: none;

--- a/templates/shortcodes/youtube.html
+++ b/templates/shortcodes/youtube.html
@@ -1,0 +1,10 @@
+<div class="video{% if class %} {{class}}{% endif %}">
+    <iframe
+        src="https://www.youtube.com/embed/{{id}}?rel=0{% if autoplay %}&autoplay=1{% endif %}"
+		allow="autoplay; encrypted-media"
+		frameborder="0"
+        webkitallowfullscreen
+        mozallowfullscreen
+        allowfullscreen>
+    </iframe>
+</div>

--- a/templates/shortcodes/youtube.html
+++ b/templates/shortcodes/youtube.html
@@ -1,8 +1,8 @@
 <div class="video{% if class %} {{class}}{% endif %}">
     <iframe
         src="https://www.youtube.com/embed/{{id}}?rel=0{% if autoplay %}&autoplay=1{% endif %}"
-		allow="autoplay; encrypted-media"
-		frameborder="0"
+        allow="autoplay; encrypted-media"
+        frameborder="0"
         webkitallowfullscreen
         mozallowfullscreen
         allowfullscreen>


### PR DESCRIPTION
I figured it'd be nice to support YouTube embeds neatly out-of-the-box - please point me in the right direction if this is already supported and I missed it!

Example project `.md` would look like this, nice and simple:
```
# Teaser trailer

The footage for this trailer was all captured in real-time at 30fps using ray-traced reflections in an internal prototype engine.

{{ youtube(id="LXo0WdlELJk") }}
```
Ends up looking something like this:
![image](https://github.com/justint/papaya/assets/7034577/982fdda5-5bf6-4696-b302-f820301e7268)

You can also supply a custom `class` argument if you want to style it further.