### PR TITLE
Consistency pass on href outputs

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -15,8 +15,8 @@
     <link rel="stylesheet" href="{{ get_url(path="base.css", trailing_slash=false) }}">
     <link rel="stylesheet" href="{{ get_url(path=color_mode_css_path, trailing_slash=false) }}">
 
-    <link rel="preload" href={{ config.extra.cdn.font_awesome }} as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href={{ config.extra.cdn.font_awesome }}></noscript>
+    <link rel="preload" href="{{ config.extra.cdn.font_awesome | safe }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="{{ config.extra.cdn.font_awesome | safe }}"></noscript>
 
     {% if config.generate_feed %}
     <link rel="alternate" type={% if config.feed_filename == "atom.xml" %}"application/atom+xml"{% else %}"application/rss+xml"{% endif %} title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
@@ -36,14 +36,14 @@
     {% set base_url = get_url(path="", lang=lang) %}
     <header>
         <h1 class="site-header">
-            <a href="{{ base_url }}">{{ config.title }}</a>
+            <a href="{{ base_url | safe }}">{{ config.title }}</a>
         </h1>
         <nav>
             <ul>
             {% block nav_bar %}
             {% for subsec in config.extra.menu_items %}
                 {% set link_url = subsec.url | replace(from="$BASE_URL", to=config.base_url) | replace(from="$LANG_BASE_URL", to=base_url) %}
-                <li><a {% if current_url and current_url is starting_with(link_url) %}class="active"{% endif %} href="{{ link_url }}">{{ trans(key=subsec.name, lang=lang) }}</a></li>
+                <li><a {% if current_url and current_url is starting_with(link_url) %}class="active"{% endif %} href="{{ link_url | safe }}">{{ trans(key=subsec.name, lang=lang) }}</a></li>
             {% endfor %}
             {% endblock nav_bar %}
             </ul>

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -12,7 +12,7 @@
         {% else %}
             {% set tags_url = "/tags" %}
         {% endif %}
-        {{ trans(key="view_by", lang=lang) }}: <a href={{ tags_url }}>{{ trans(key="tags", lang=lang) }}</a>
+        {{ trans(key="view_by", lang=lang) }}: <a href="{{ tags_url | safe }}">{{ trans(key="tags", lang=lang) }}</a>
     </p>
     {% endblock heading %}
     {% if paginator.pages %}

--- a/templates/categories/list.html
+++ b/templates/categories/list.html
@@ -9,7 +9,7 @@
 <ul class="terms">
     {% for term in terms %}
     <li>
-        <a href="{{ term.permalink }}">
+        <a href="{{ term.permalink | safe }}">
         {{ term.name }}
         </a>
         ({{ term.pages | length }})

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
             {% for page in subsec_section_pages | slice(end=subsec.recent_items) %}
                 {{ page_macros::page_listing(page=page) }}
             {% endfor %}
-            <p class="read-more"><a href={{ subsec_link_path }}>{{ trans(key=subsec.more_trans_key, lang=lang) }} ≫</a></p>
+            <p class="read-more"><a href="{{ subsec_link_path | safe }}">{{ trans(key=subsec.more_trans_key, lang=lang) }} ≫</a></p>
         </section>
     {% endfor %}
     </section>

--- a/templates/macros/page.html
+++ b/templates/macros/page.html
@@ -26,7 +26,7 @@
 
 {% macro page_listing(page) %}
     <article class="post-list">
-        <a href="{{ page.permalink }}">
+        <a href="{{ page.permalink | safe }}">
             <header>
                 <h3>
                     {{ page.title }}

--- a/templates/macros/page.html
+++ b/templates/macros/page.html
@@ -63,10 +63,10 @@
 {% macro project_listing(page) %}
 <article class="post-list">
 {#    {% if page.extra.featured_image %}
-    <a href="{{ page.permalink }}"><img src="{{ page.permalink }}/{{ page.extra.featured_image }}" alt="{% if page.extra.featured_image_alt %}{{ page.extra.featured_image_alt }}{% else %}{{ page.title }}{% endif %}"/></a>
+    <a href="{{ page.permalink | safe }}"><img src="{{ page.permalink | safe }}/{{ page.extra.featured_image }}" alt="{% if page.extra.featured_image_alt %}{{ page.extra.featured_image_alt }}{% else %}{{ page.title }}{% endif %}"/></a>
     {% endif %}
 #}
-    <a href="{{ page.permalink }}">
+    <a href="{{ page.permalink | safe }}">
         <header>
             <h3>
                 {{ page.title }}

--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -68,7 +68,7 @@
 
   {% if social_config.other %}
   {% for social in social_config.other %}
-  <a href={{ social.url }} aria-label="Open {{ social.name }}" target="_blank">
+  <a href="{{ social.url | safe }}" aria-label="Open {{ social.name }}" target="_blank">
     <span class="icon is-large">
       <i class="{{ social.font_awesome }} fa-lg" aria-hidden="true" title={{ social.name }}></i>
     </span>

--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -9,7 +9,7 @@
 <ul class="terms">
     {% for term in terms %}
     <li>
-        <a href="{{ term.permalink }}">
+        <a href="{{ term.permalink | safe }}">
         #{{ term.name }}
         </a>
         ({{ term.pages | length }})


### PR DESCRIPTION
Now they all have double quotes and all processed as safe, so it doesn't end up with HTML codes in the output URL.

For example, before this change, the `<head>` section would contain raw code as such:
```
    <link rel="preload" href=https:&#x2F;&#x2F;cdnjs.cloudflare.com&#x2F;ajax&#x2F;libs&#x2F;font-awesome&#x2F;6.3.0&#x2F;css&#x2F;all.min.css as="style" onload="this.onload=null;this.rel='stylesheet'">
    <noscript><link rel="stylesheet" href=https:&#x2F;&#x2F;cdnjs.cloudflare.com&#x2F;ajax&#x2F;libs&#x2F;font-awesome&#x2F;6.3.0&#x2F;css&#x2F;all.min.css></noscript>
```

After this change, the raw output is more consistent and clear:
```
    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/css/all.min.css"></noscript>
```

Similarly, the site header links were not processed as `safe` so they also looked similarly odd in the raw code.