### PR TITLE
Change banner to be overridable

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,8 +4,10 @@
 {% block content %}
 <main id="main" class="index" tabindex="-1">
     <section>
+        {% block banner %}
         {% set banner = resize_image(path="/static/banner.jpg", width=672, op="fit_width") %}
         <img src="{{ banner.url }}" class="index-banner" alt="A misty forest."/>
+        {% endblock banner %}
         <p>
             {{ config.description }}
         </p>


### PR DESCRIPTION
Allows the alt text to be customised.

Currently the whole index.html would need to be altered, just to set the banner alt text, with this change, only the banner block needs to be overriden like this:
```
{% extends "papaya/templates/index.html" %}
{% block banner %}
<img src="{{ banner.url }}" class="index-banner" alt="Not a misty forest, but something else"/>
{% endblock banner %}
```